### PR TITLE
Great post. Few suggestions. Take 'em or leave 'em

### DIFF
--- a/content/2015-11-19-my-inspiration.md
+++ b/content/2015-11-19-my-inspiration.md
@@ -4,14 +4,12 @@ date : 2015-11-19
 description : A series where I describe people, mostly programmers, who inspire me to take action and not give up.
 ---
 
-Couple months ago I've talked to my friend Tomek (who happens to be IT manager, public speaker and a personal coach as well) and I've decided I want to recognize people who inspire me to action. I want it, because as Nelson Mandela rightly pointed out: *"some things seem to be impossible until their done"*.
+Couple months ago I've talked to my friend Tomek - an IT manager, public speaker and personal coach. He suggested that I should recognize people who inspire me to take action. Ever since I've wanted to write this post but stuck with thought that it has to be perfect.
 
-I've wanted to write such post for a long time but stuck with thought that it has to be perfect.
+Things changed yesterday when I was listening to another episode of Jonathan's Cutrell Developer *Tea podcast*: [How To Make Small Things A Big Deal, Plus: Celebrating 2 Million Listens!](https://developertea.com/episodes/19955). He made me realize that great things are made of small ones. No great thing was achieved in one day.
 
-Things changed yesterday when I was listening Jonathan's Cutrell Developer Tea podcast [How To Make Small Things A Big Deal, Plus: Celebrating 2 Million Listens!](https://developertea.com/episodes/19955) I realized, that great things are made of small ones. None of great things were achieved in one day.
+**Jonathan Cutrell**, whose podcast pushed me to action today deserves first post in this series. He is a web developer and creator of *Developer Tea* - a podcasts on programming topics. As far as I know he publishes one episode every two days.  It's an amazing achievement. Episodes are usually about 10 minutes long so I listen to them when I can't do anything else, like when I'm  waiting for the bus, making breakfast or in the evening when I'm too tired to listen to other one-and-a-half-hour-long podcasts.
 
-Of course many people many people inspire me, but the first post from this series is about **Jonathan Cutrell**, whose podcast pushed me to action today. He is a Web Developer and creates short podcasts on programming topics. As far as I know, he publish one podcast every two days, which is an amazing achievement. I listen to them when I can't do anything else. It takes only 10 minutes -  waiting for the bus, making breakfast or in the evening when I'm already too tired to listen other one-and-a-half-hour-long podcasts.
-
-He sees an opportunity where other people don't. That's why I recommend his podcasts, especially to beginners in a moments of doubt :)
+He sees an opportunities where other people don't. That's why I recommend his podcast, especially to beginners in a moments of doubt :)
 
 You can listen to him at [Developer Tea](https://developertea.com/).


### PR DESCRIPTION
Keep it short and sweet:

Drop Nelson Mandela quote - it seemed inaccurate (http://www.usatoday.com/story/news/nation-now/2013/12/05/nelson-mandela-quotes/3775255/), had typo (~~their~~ -> they are) and IMO didn't add value to your text.

Podcast is a series of episodes, so in this context it should be singular. You listen to podcast or to episodes. Also podcast isn't short - episodes are :)

I also tried to consolidate your text to avoid repetitions and enhance flow.

Hope you like the changes :)
